### PR TITLE
chore: adding tests for release-backed publishes

### DIFF
--- a/src/lib/write-package.ts
+++ b/src/lib/write-package.ts
@@ -295,16 +295,17 @@ async function enforceMatchingRelease(
   res: Response
 ) {
   try {
-    const newPackument = JSON.parse(drainedBody + '') as Packument;
-    // Some types of updates don't include a full packument, e.g., changing
-    // a dist-tag:
-    if (!newPackument['dist-tags']) {
+    const maybePackument = JSON.parse(drainedBody + '');
+    if (
+      typeof maybePackument !== 'object' ||
+      maybePackument['dist-tags'] === undefined
+    ) {
       throw new WombatServerError(
         'Release-backed tokens should be used exclusively for publication.',
         400
       );
     }
-
+    const newPackument = maybePackument as Packument;
     let newVersion =
       newPackument.versions[newPackument['dist-tags'].latest || ''].version;
     // If this is not the first package publication, we infer the version being

--- a/test/helpers/write-package-request.ts
+++ b/test/helpers/write-package-request.ts
@@ -3,7 +3,7 @@ import {Request} from 'express';
 
 export function writePackageRequest(
   headers: {[key: string]: string},
-  packument?: Packument
+  packument?: Packument | string
 ): Request {
   return {
     headers,

--- a/test/lib/write-package.ts
+++ b/test/lib/write-package.ts
@@ -61,6 +61,7 @@ describe('writePackage', () => {
       .reply(404);
 
     const ret = await writePackage('@soldair/foo', req, res);
+    npmRequest.done();
     expect(ret.error).to.match(/must have a repository/);
     expect(ret.statusCode).to.equal(400);
   });
@@ -116,8 +117,184 @@ describe('writePackage', () => {
         .reply(200, {tag_name: 'v1.0.0'});
 
       const ret = await writePackage('@soldair/foo', req, res);
+      npmRequest.done();
+      githubRequest.done();
       expect(ret.newPackage).to.equal(true);
       expect(ret.statusCode).to.equal(200);
+    });
+
+    it('allows a package to be updated', async () => {
+      // Fake that there's a releaseAs2FA key in datastore:
+      writePackage.datastore = Object.assign({}, datastore, {
+        getPublishKey: async (
+          username: string
+        ): Promise<PublishKey | false> => {
+          return {
+            username: 'bcoe',
+            created: 1578630249529,
+            value: 'deadbeef',
+            releaseAs2FA: true,
+          };
+        },
+        getUser: async (username: string): Promise<false | User> => {
+          return {name: 'bcoe', token: 'deadbeef'};
+        },
+      });
+      writePackage.pipeToNpm = (
+        req: Request,
+        res: Response,
+        drainedBody: false | Buffer,
+        newPackage: boolean
+      ): Promise<WriteResponse> => {
+        return Promise.resolve({statusCode: 200, newPackage});
+      };
+
+      // Simulate a publication request to the proxy:
+      const req = writePackageRequest(
+        {authorization: 'token: abc123'},
+        createPackument('@soldair/foo')
+          .addVersion('1.0.0', 'https://github.com/foo/bar')
+          .packument()
+      );
+      const res = {status: (code: number) => {}, end: () => {}} as Response;
+
+      const npmRequest = nock('https://registry.npmjs.org')
+        .get('/@soldair%2ffoo')
+        .reply(
+          200,
+          createPackument('@soldair/foo')
+            .addVersion('0.1.0', 'https://github.com/foo/bar')
+            .packument()
+        );
+
+      const githubRequest = nock('https://api.github.com')
+        // user has push access to repo in package.json
+        .get('/repos/foo/bar')
+        .reply(200, {permissions: {push: true}})
+        // most recent release tag on GitHub is v1.0.0
+        .get('/repos/foo/bar/releases/latest')
+        .reply(200, {tag_name: 'v1.0.0'});
+
+      const ret = await writePackage('@soldair/foo', req, res);
+      npmRequest.done();
+      githubRequest.done();
+      expect(ret.newPackage).to.equal(false);
+      expect(ret.statusCode).to.equal(200);
+    });
+
+    it("does not allow PUTs that aren't publications, e.g., dist-tag updates", async () => {
+      // Fake that there's a releaseAs2FA key in datastore:
+      writePackage.datastore = Object.assign({}, datastore, {
+        getPublishKey: async (
+          username: string
+        ): Promise<PublishKey | false> => {
+          return {
+            username: 'bcoe',
+            created: 1578630249529,
+            value: 'deadbeef',
+            releaseAs2FA: true,
+          };
+        },
+        getUser: async (username: string): Promise<false | User> => {
+          return {name: 'bcoe', token: 'deadbeef'};
+        },
+      });
+      writePackage.pipeToNpm = (
+        req: Request,
+        res: Response,
+        drainedBody: false | Buffer,
+        newPackage: boolean
+      ): Promise<WriteResponse> => {
+        return Promise.resolve({statusCode: 200, newPackage});
+      };
+
+      // simulate a dist-tag update:
+      const req = writePackageRequest(
+        {authorization: 'token: abc123'},
+        '0.2.3'
+      );
+      const res = {status: (code: number) => {}, end: () => {}} as Response;
+
+      // A 404 while fetching the packument indicates that the package
+      // has not yet been created:
+      const npmRequest = nock('https://registry.npmjs.org')
+        .get('/@soldair%2ffoo')
+        .reply(
+          200,
+          createPackument('@soldair/foo')
+            .addVersion('1.0.0', 'https://github.com/foo/bar')
+            .packument()
+        );
+
+      const githubRequest = nock('https://api.github.com')
+        // user has push access to repo in package.json
+        .get('/repos/foo/bar')
+        .reply(200, {permissions: {push: true}});
+
+      const ret = await writePackage('@soldair/foo', req, res);
+      npmRequest.done();
+      githubRequest.done();
+      expect(ret.error).to.match(/used exclusively for publication/);
+      expect(ret.statusCode).to.equal(400);
+    });
+
+    it('rejects publication if no corresponding release found on GitHub', async () => {
+      // Fake that there's a releaseAs2FA key in datastore:
+      writePackage.datastore = Object.assign({}, datastore, {
+        getPublishKey: async (
+          username: string
+        ): Promise<PublishKey | false> => {
+          return {
+            username: 'bcoe',
+            created: 1578630249529,
+            value: 'deadbeef',
+            releaseAs2FA: true,
+          };
+        },
+        getUser: async (username: string): Promise<false | User> => {
+          return {name: 'bcoe', token: 'deadbeef'};
+        },
+      });
+      writePackage.pipeToNpm = (
+        req: Request,
+        res: Response,
+        drainedBody: false | Buffer,
+        newPackage: boolean
+      ): Promise<WriteResponse> => {
+        return Promise.resolve({statusCode: 200, newPackage});
+      };
+
+      // Simulate a publication request to the proxy:
+      const req = writePackageRequest(
+        {authorization: 'token: abc123'},
+        createPackument('@soldair/foo')
+          .addVersion('1.0.0', 'https://github.com/foo/bar')
+          .packument()
+      );
+      const res = {status: (code: number) => {}, end: () => {}} as Response;
+
+      const npmRequest = nock('https://registry.npmjs.org')
+        .get('/@soldair%2ffoo')
+        .reply(
+          200,
+          createPackument('@soldair/foo')
+            .addVersion('0.1.0', 'https://github.com/foo/bar')
+            .packument()
+        );
+
+      const githubRequest = nock('https://api.github.com')
+        // user has push access to repo in package.json
+        .get('/repos/foo/bar')
+        .reply(200, {permissions: {push: true}})
+        // most recent release tag on GitHub is v0.1.0
+        .get('/repos/foo/bar/releases/latest')
+        .reply(200, {tag_name: 'v0.1.0'});
+
+      const ret = await writePackage('@soldair/foo', req, res);
+      npmRequest.done();
+      githubRequest.done();
+      expect(ret.error).to.match(/matching release v1.0.0 not found/);
+      expect(ret.statusCode).to.equal(400);
     });
   });
 });


### PR DESCRIPTION
Adding tests for release backed tokens.
