### PR TITLE
fix: login was broken due to missing JS import

### DIFF
--- a/views/token-settings.hbs
+++ b/views/token-settings.hbs
@@ -50,5 +50,5 @@
       <button>Create</button>
     </form>
   </div>
-  <script src="token-settings.js"></script>
+  <script src="/token-settings.js"></script>
 </article>


### PR DESCRIPTION
The refactor to hbs changed the root path to `/_`, which broke JavaScript imports, which had no root.