### PR TITLE
feat(release-backed): allow a candidate release to be published to next tag

### DIFF
--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -56,16 +56,18 @@ export const getRepo = (name: string, token: string): Promise<GhRepo> => {
  * https://developer.github.com/v3/repos/releases/#list-releases-for-a-repository
  * @param name repository name including username. ex: node/node or bcoe/yargs
  * @param token
+ * @param tag release tag to fetch.
  *
  * @returns string[] tag names of releases.
  */
-export const getLatestRelease = (
+export const getRelease = (
   name: string,
-  token: string
+  token: string,
+  tag: string
 ): Promise<string> => {
   const client = gh.client(token, clientOptions);
   return client
-    .release(name, 'latest')
+    .release(name, `tags/${tag}`)
     .infoAsync()
     .then((release: Array<{[key: string]: string}>) => {
       return release[0].tag_name;

--- a/test/helpers/create-packument.ts
+++ b/test/helpers/create-packument.ts
@@ -19,8 +19,10 @@ import {Packument, PackumentVersion, Repository} from '@npm/types';
 class PackumentBuilder {
   versions: PackumentVersion[] = [];
   name: string;
-  constructor(name: string) {
+  tag: string;
+  constructor(name: string, tag = 'latest') {
     this.name = name;
+    this.tag = tag;
   }
   addVersion(
     versionNumber: string,
@@ -52,12 +54,15 @@ class PackumentBuilder {
     } as Packument;
     for (const version of this.versions) {
       packument.versions[version.version] = version;
-      packument['dist-tags'].latest = version.version;
+      packument['dist-tags'][this.tag] = version.version;
     }
     return packument;
   }
 }
 
-export function createPackument(name: string): PackumentBuilder {
-  return new PackumentBuilder(name);
+export function createPackument(
+  name: string,
+  tag = 'latest'
+): PackumentBuilder {
+  return new PackumentBuilder(name, tag);
 }

--- a/test/lib/github.ts
+++ b/test/lib/github.ts
@@ -25,20 +25,20 @@ describe('github', () => {
   describe('getLatestRelease', () => {
     it('returns latest release from GitHub', async () => {
       const request = nock('https://api.github.com')
-        .get('/repos/bcoe/test/releases/latest')
+        .get('/repos/bcoe/test/releases/tags/v1.0.2')
         .reply(200, {tag_name: 'v1.0.2'});
-      const latest = await github.getLatestRelease('bcoe/test', 'abc123');
+      const latest = await github.getRelease('bcoe/test', 'abc123', 'v1.0.2');
       expect(latest).to.equal('v1.0.2');
       request.done();
     });
 
     it('bubbles error appropriately', async () => {
       const request = nock('https://api.github.com')
-        .get('/repos/bcoe/test/releases/latest')
+        .get('/repos/bcoe/test/releases/tags/v1.0.2')
         .reply(404);
       let err: Error | undefined = undefined;
       try {
-        await github.getLatestRelease('bcoe/test', 'abc123');
+        await github.getRelease('bcoe/test', 'abc123', 'v1.0.2');
       } catch (_err) {
         err = _err;
       }


### PR DESCRIPTION
Give release backed publications the ability to publish to a `next` tag on npm.