### PR TITLE
fix(release-backed): look at tags rather than releases

### DIFF
--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -80,7 +80,7 @@ export const getRelease = (
             return item.name === tag;
           })
         ) {
-          return reject(Error('not found'));
+          return reject(new Error('not found'));
         } else {
           return resolve(tag);
         }

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -74,7 +74,7 @@ export const getRelease = (
         if (err) {
           return reject(err);
         } else if (code !== 200)
-          return reject(Error(`unexpected http code = ${code}`));
+          return reject(new Error(`unexpected http code = ${code}`));
         else if (
           !resp.find(item => {
             return item.name === tag;

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -66,12 +66,27 @@ export const getRelease = (
   tag: string
 ): Promise<string> => {
   const client = gh.client(token, clientOptions);
-  return client
-    .release(name, `tags/${tag}`)
-    .infoAsync()
-    .then((release: Array<{[key: string]: string}>) => {
-      return release[0].tag_name;
-    });
+  return new Promise((resolve, reject) => {
+    client.get(
+      `/repos/${name}/tags`,
+      {per_page: 100},
+      (err: Error, code: number, resp: [{name: string}]) => {
+        if (err) {
+          return reject(err);
+        } else if (code !== 200)
+          return reject(Error(`unexpected http code = ${code}`));
+        else if (
+          !resp.find(item => {
+            return item.name === tag;
+          })
+        ) {
+          return reject(Error('not found'));
+        } else {
+          return resolve(tag);
+        }
+      }
+    );
+  });
 };
 
 /**

--- a/src/lib/write-package.ts
+++ b/src/lib/write-package.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {Packument, PackumentVersion} from '@npm/types';
+import {Packument} from '@npm/types';
 import {Request, Response} from 'express';
 import * as request from 'request';
 

--- a/test/lib/github.ts
+++ b/test/lib/github.ts
@@ -25,8 +25,9 @@ describe('github', () => {
   describe('getLatestRelease', () => {
     it('returns latest release from GitHub', async () => {
       const request = nock('https://api.github.com')
-        .get('/repos/bcoe/test/releases/tags/v1.0.2')
-        .reply(200, {tag_name: 'v1.0.2'});
+        .get('/repos/bcoe/test/tags?per_page=100')
+        .reply(200, [{name: 'v1.0.2'}]);
+
       const latest = await github.getRelease('bcoe/test', 'abc123', 'v1.0.2');
       expect(latest).to.equal('v1.0.2');
       request.done();
@@ -34,7 +35,7 @@ describe('github', () => {
 
     it('bubbles error appropriately', async () => {
       const request = nock('https://api.github.com')
-        .get('/repos/bcoe/test/releases/tags/v1.0.2')
+        .get('/repos/bcoe/test/tags?per_page=100')
         .reply(404);
       let err: Error | undefined = undefined;
       try {
@@ -44,7 +45,7 @@ describe('github', () => {
       }
       expect(err).to.not.equal(undefined);
       if (err) {
-        expect(err.message).to.include('Release info error');
+        expect(err.message).to.include('unexpected http code');
       }
       request.done();
     });

--- a/test/lib/write-package.ts
+++ b/test/lib/write-package.ts
@@ -138,8 +138,8 @@ describe('writePackage', () => {
         .get('/repos/foo/bar')
         .reply(200, {permissions: {push: true}})
         // most recent release tag on GitHub is v1.0.0
-        .get('/repos/foo/bar/releases/tags/v1.0.0')
-        .reply(200, {tag_name: 'v1.0.0'});
+        .get('/repos/foo/bar/tags?per_page=100')
+        .reply(200, [{name: 'v1.0.0'}]);
 
       const ret = await writePackage('@soldair/foo', req, res);
       npmRequest.done();
@@ -197,8 +197,8 @@ describe('writePackage', () => {
         .get('/repos/foo/bar')
         .reply(200, {permissions: {push: true}})
         // most recent release tag on GitHub is v1.0.0
-        .get('/repos/foo/bar/releases/tags/v1.0.0')
-        .reply(200, {tag_name: 'v1.0.0'});
+        .get('/repos/foo/bar/tags?per_page=100')
+        .reply(200, [{name: 'v1.0.0'}]);
 
       const ret = await writePackage('@soldair/foo', req, res);
       npmRequest.done();
@@ -256,8 +256,8 @@ describe('writePackage', () => {
         .get('/repos/foo/bar')
         .reply(200, {permissions: {push: true}})
         // most recent release tag on GitHub is v1.0.0
-        .get('/repos/foo/bar/releases/tags/v1.0.0')
-        .reply(200, {tag_name: 'v1.0.0'});
+        .get('/repos/foo/bar/tags?per_page=100')
+        .reply(200, [{name: 'v1.0.0'}]);
 
       const ret = await writePackage('@soldair/foo', req, res);
       npmRequest.done();
@@ -371,8 +371,67 @@ describe('writePackage', () => {
         .get('/repos/foo/bar')
         .reply(200, {permissions: {push: true}})
         // most recent release tag on GitHub is v0.1.0
-        .get('/repos/foo/bar/releases/tags/v1.0.0')
-        .reply(404);
+        .get('/repos/foo/bar/tags?per_page=100')
+        .reply(200, [{name: 'v0.1.0'}]);
+
+      const ret = await writePackage('@soldair/foo', req, res);
+      npmRequest.done();
+      githubRequest.done();
+      expect(ret.error).to.match(/matching release v1.0.0 not found/);
+      expect(ret.statusCode).to.equal(400);
+    });
+
+    it('rejects publication if listing tags rerturns non-200', async () => {
+      // Fake that there's a releaseAs2FA key in datastore:
+      writePackage.datastore = Object.assign({}, datastore, {
+        getPublishKey: async (
+          _username: string
+        ): Promise<PublishKey | false> => {
+          return {
+            username: 'bcoe',
+            created: 1578630249529,
+            value: 'deadbeef',
+            releaseAs2FA: true,
+          };
+        },
+        getUser: async (_username: string): Promise<false | User> => {
+          return {name: 'bcoe', token: 'deadbeef'};
+        },
+      });
+      writePackage.pipeToNpm = (
+        req: Request,
+        res: Response,
+        drainedBody: false | Buffer,
+        newPackage: boolean
+      ): Promise<WriteResponse> => {
+        return Promise.resolve({statusCode: 200, newPackage});
+      };
+
+      // Simulate a publication request to the proxy:
+      const req = writePackageRequest(
+        {authorization: 'token: abc123'},
+        createPackument('@soldair/foo')
+          .addVersion('1.0.0', 'https://github.com/foo/bar')
+          .packument()
+      );
+      const res = mockResponse();
+
+      const npmRequest = nock('https://registry.npmjs.org')
+        .get('/@soldair%2ffoo')
+        .reply(
+          200,
+          createPackument('@soldair/foo')
+            .addVersion('0.1.0', 'https://github.com/foo/bar')
+            .packument()
+        );
+
+      const githubRequest = nock('https://api.github.com')
+        // user has push access to repo in package.json
+        .get('/repos/foo/bar')
+        .reply(200, {permissions: {push: true}})
+        // most recent release tag on GitHub is v0.1.0
+        .get('/repos/foo/bar/tags?per_page=100')
+        .reply(500);
 
       const ret = await writePackage('@soldair/foo', req, res);
       npmRequest.done();


### PR DESCRIPTION
Switch to using tags rather than releases, when checking release-backed publication tokens.

_Note: I can't find it documented, but using the API it appears that tags are returned in reverse chronological order of when they were created, so I believe this should be a drop in replacement for the approach of looking at releases._

CC: @mathiasbynens