### PR TITLE
fix: check more pages of tags

### DIFF
--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -70,9 +70,9 @@ export const getRelease = async (
   prefix?: string
 ): Promise<string | undefined> => {
   const client = gh.client(token, clientOptions);
-  // We check up to 600 of the most recent tags for a matching release,
+  // We check up to 1200 of the most recent tags for a matching release,
   // we use a large page size to allow for monorepos with 100s of tags:
-  const maxPagination = 6;
+  const maxPagination = 12;
   for (let page = 1; page < maxPagination; page++) {
     const tags: [{name: string}] = await new Promise((resolve, reject) => {
       client.get(

--- a/test/lib/github.ts
+++ b/test/lib/github.ts
@@ -61,7 +61,19 @@ describe('github', () => {
         .get('/repos/bcoe/test/tags?per_page=100&page=4')
         .reply(200, [{name: 'v1.0.5'}])
         .get('/repos/bcoe/test/tags?per_page=100&page=5')
-        .reply(200, [{name: 'v1.0.6'}]);
+        .reply(200, [{name: 'v1.0.6'}])
+        .get('/repos/bcoe/test/tags?per_page=100&page=6')
+        .reply(200, [{name: 'v1.0.7'}])
+        .get('/repos/bcoe/test/tags?per_page=100&page=7')
+        .reply(200, [{name: 'v1.0.8'}])
+        .get('/repos/bcoe/test/tags?per_page=100&page=8')
+        .reply(200, [{name: 'v1.0.9'}])
+        .get('/repos/bcoe/test/tags?per_page=100&page=9')
+        .reply(200, [{name: 'v1.0.10'}])
+        .get('/repos/bcoe/test/tags?per_page=100&page=10')
+        .reply(200, [{name: 'v1.0.10'}])
+        .get('/repos/bcoe/test/tags?per_page=100&page=11')
+        .reply(200, [{name: 'v1.0.10'}]);
 
       expect(
         await github.getRelease('bcoe/test', 'abc123', 'v1.0.2', 'foo')

--- a/test/lib/write-package.ts
+++ b/test/lib/write-package.ts
@@ -367,6 +367,18 @@ describe('writePackage', () => {
         .get('/repos/foo/bar/tags?per_page=100&page=4')
         .reply(200, [{name: 'v0.1.0'}])
         .get('/repos/foo/bar/tags?per_page=100&page=5')
+        .reply(200, [{name: 'v0.1.0'}])
+        .get('/repos/foo/bar/tags?per_page=100&page=6')
+        .reply(200, [{name: 'v0.1.0'}])
+        .get('/repos/foo/bar/tags?per_page=100&page=7')
+        .reply(200, [{name: 'v0.1.0'}])
+        .get('/repos/foo/bar/tags?per_page=100&page=8')
+        .reply(200, [{name: 'v0.1.0'}])
+        .get('/repos/foo/bar/tags?per_page=100&page=9')
+        .reply(200, [{name: 'v0.1.0'}])
+        .get('/repos/foo/bar/tags?per_page=100&page=10')
+        .reply(200, [{name: 'v0.1.0'}])
+        .get('/repos/foo/bar/tags?per_page=100&page=11')
         .reply(200, [{name: 'v0.1.0'}]);
 
       const ret = await writePackage('@soldair/foo', req, res);


### PR DESCRIPTION
The GitHub API returns tags alphabetically, rather than chronologically, this means that in mono-repos we will potentially not find a tag if there have been more than 600 releases.

As a more permanent fix for this, I believe we should check both releases and tags, but this is a good start.