### PR TITLE
feat: treating unpublished packages as if they were new

### DIFF
--- a/src/lib/write-package.ts
+++ b/src/lib/write-package.ts
@@ -85,9 +85,10 @@ export const writePackage = async (
   let doc = await packument(packageName);
 
   let latest = undefined;
+
   let newPackage = false;
   let drainedBody: false | Buffer = false;
-  if (!doc) {
+  if (!doc || doc?.time?.unpublished) {
     // this is a completely new package.
     newPackage = true;
     drainedBody = await drainRequest(req);


### PR DESCRIPTION
This fixes the case where when a package has been completely unpublished wombat refuses to publish the first new version.
