### PR TITLE
feat: search matching releases on GitHub before falling back to tags

### DIFF
--- a/packages/server/test/lib/github.ts
+++ b/packages/server/test/lib/github.ts
@@ -22,9 +22,49 @@ import * as github from '../../src/lib/github';
 nock.disableNetConnect();
 
 describe('github', () => {
-  describe('getLatestRelease', () => {
-    it('returns latest release from GitHub', async () => {
+  describe('getRelease', () => {
+    it('returns matching release from GitHub', async () => {
       const request = nock('https://api.github.com')
+        .get('/repos/bcoe/test/releases/tags/v1.0.2')
+        .reply(200, {name: 'v1.0.2'});
+
+      const latest = await github.getRelease('bcoe/test', 'abc123', ['v1.0.2']);
+      expect(latest).to.equal('v1.0.2');
+      request.done();
+    });
+
+    it('returns release matching monorepo-style tag', async () => {
+      const request = nock('https://api.github.com')
+        .get('/repos/bcoe/test/releases/tags/test-v1.0.2')
+        .reply(200, {name: 'test-v1.0.2'});
+
+      const latest = await github.getRelease('bcoe/test', 'abc123', [
+        'test-v1.0.2',
+        '@bcoe/test@1.0.2',
+      ]);
+      expect(latest).to.equal('test-v1.0.2');
+      request.done();
+    });
+
+    it('returns release matching lerna-style tag', async () => {
+      const request = nock('https://api.github.com')
+        .get('/repos/bcoe/test/releases/tags/test-v1.0.2')
+        .reply(404, {})
+        .get('/repos/bcoe/test/releases/tags/@bcoe/test@1.0.2')
+        .reply(200, {name: '@bcoe/test@1.0.2'});
+
+      const latest = await github.getRelease('bcoe/test', 'abc123', [
+        'test-v1.0.2',
+        '@bcoe/test@1.0.2',
+      ]);
+      expect(latest).to.equal('@bcoe/test@1.0.2');
+      request.done();
+    });
+
+    it('returns matching tag from GitHub if no release found', async () => {
+      const request = nock('https://api.github.com')
+        .get('/repos/bcoe/test/releases/tags/v1.0.2')
+        .reply(404, {})
         .get('/repos/bcoe/test/tags?per_page=100&page=1')
         .reply(200, [{name: 'v1.0.2'}]);
 
@@ -35,6 +75,8 @@ describe('github', () => {
 
     it('bubbles error appropriately', async () => {
       const request = nock('https://api.github.com')
+        .get('/repos/bcoe/test/releases/tags/v1.0.2')
+        .reply(404, {})
         .get('/repos/bcoe/test/tags?per_page=100&page=1')
         .reply(404);
       let err: Error | undefined = undefined;
@@ -50,8 +92,12 @@ describe('github', () => {
       request.done();
     });
 
-    it('does not return latest release without prefix, when monorepo-style used', async () => {
+    it('does not return latest tag without prefix, when monorepo-style used', async () => {
       const request = nock('https://api.github.com')
+        .get('/repos/bcoe/test/releases/tags/foo-v1.0.2')
+        .reply(404, {})
+        .get('/repos/bcoe/test/releases/tags/@scope/foo@1.0.2')
+        .reply(404, {})
         .get('/repos/bcoe/test/tags?per_page=100&page=1')
         .reply(200, [{name: 'v1.0.2'}])
         .get('/repos/bcoe/test/tags?per_page=100&page=2')
@@ -77,14 +123,17 @@ describe('github', () => {
 
       expect(
         await github.getRelease('bcoe/test', 'abc123', [
-          'foo-v1.0.2, @scope/foo@1.0.2',
+          'foo-v1.0.2',
+          '@scope/foo@1.0.2',
         ])
       ).to.equal(undefined);
       request.done();
     });
 
-    it('returns latest release matching monorepo style tag', async () => {
+    it('returns latest tag matching monorepo style tag', async () => {
       const request = nock('https://api.github.com')
+        .get('/repos/bcoe/test/releases/tags/foo-v1.0.2')
+        .reply(404, {})
         .get('/repos/bcoe/test/tags?per_page=100&page=1')
         .reply(200, [{name: 'v1.0.3'}])
         .get('/repos/bcoe/test/tags?per_page=100&page=2')
@@ -99,8 +148,10 @@ describe('github', () => {
       request.done();
     });
 
-    it('returns latest release matching lerna style tag', async () => {
+    it('returns latest tag matching lerna style tag', async () => {
       const request = nock('https://api.github.com')
+        .get('/repos/bcoe/test/releases/tags/@scope/foo@1.0.2')
+        .reply(404, {})
         .get('/repos/bcoe/test/tags?per_page=100&page=1')
         .reply(200, [{name: 'v1.0.3'}])
         .get('/repos/bcoe/test/tags?per_page=100&page=2')


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/GoogleCloudPlatform/wombat-dressing-room/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Did not file an issue as discussed with Ben offline.

This PR adds additional checking for release-backed tokens. Release-backed tokens require a matching tag on GitHub. Previously this worked by fetching 11 pages of tags from GitHub and searching for a match. This approach fails for large monorepos, as each release of each package in the monorepo has its own tag. The GitHub API does not return tags in reverse chronological order. So this approach only worked for repos with under 1100 tags.

This change first checks GitHub for a matching release, because the API allows you to ask for a particular release by tag name. If a matching release is not found, it falls back to searching all tags. This is for those projects that are using tags but not GitHub releases.

Updated tests to cover both cases. Updated jsdoc for relevant methods.

Also, if there is an error while fetching releases/tags, I added the error text to the resulting message to increase debuggability.

Note: I tested this with unit tests but I wasn't able to test this with an actual running server, because I don't have all the relevant config. This should probably be tested with a running server since the unit tests can't account for e.g. misspelling the API or something. I did test the API calls with curl on the command line, but still could have made an error in the code.