### PR TITLE
fix: respond to 404 errors when checking releases, and fall back to tags

### DIFF
--- a/packages/server/src/lib/write-package.ts
+++ b/packages/server/src/lib/write-package.ts
@@ -298,13 +298,14 @@ async function enforceMatchingRelease(
       const msg = `matching release v${newVersion} not found for ${repoName}. Did not find any tags matching: ${tags.join()}`;
       throw new WombatServerError(msg, 400);
     }
-  } catch (_err) {
-    // TODO(#158): This can swallow some errors that do have messages
-    const err = _err as {statusMessage: string; statusCode: number};
-    if (err.statusCode && err.statusMessage) throw err;
-    err.statusCode = 500;
-    err.statusMessage = 'unknown error';
-    throw err;
+  } catch (err) {
+    if (err instanceof WombatServerError) {
+      throw err;
+    }
+    if (err instanceof Error) {
+      throw new WombatServerError(err.message || 'unknown error', 500);
+    }
+    throw new WombatServerError('unknown error', 500);
   }
 }
 

--- a/packages/server/test/lib/write-package.ts
+++ b/packages/server/test/lib/write-package.ts
@@ -134,7 +134,7 @@ describe('writePackage', () => {
         .reply(200, {permissions: {push: true}})
         // No releases on GitHub, only tags.
         .get('/repos/foo/bar/releases/tags/v1.0.0')
-        .reply(404, {})
+        .replyWithError({statusCode: 404})
         // most recent release tag on GitHub is v1.0.0
         .get('/repos/foo/bar/tags?per_page=100&page=1')
         .reply(200, [{name: 'v1.0.0'}]);
@@ -251,7 +251,7 @@ describe('writePackage', () => {
         .reply(200, {permissions: {push: true}})
         // No release on GitHub, only tags.
         .get('/repos/foo/bar/releases/tags/v1.0.0')
-        .reply(404, {})
+        .replyWithError({statusCode: 404})
         // most recent tag on GitHub is v1.0.0
         .get('/repos/foo/bar/tags?per_page=100&page=1')
         .reply(200, [{name: 'v1.0.0'}]);
@@ -365,7 +365,7 @@ describe('writePackage', () => {
         .reply(200, {permissions: {push: true}})
         // No matching release.
         .get('/repos/foo/bar/releases/tags/v1.0.0')
-        .reply(404, {})
+        .replyWithError({statusCode: 404})
         // most recent release tag on GitHub is v0.1.0
         .get('/repos/foo/bar/tags?per_page=100&page=1')
         .reply(200, [{name: 'v0.1.0'}])
@@ -445,7 +445,7 @@ describe('writePackage', () => {
         .reply(200, {permissions: {push: true}})
         // No matching release
         .get('/repos/foo/bar/releases/tags/v1.0.0')
-        .reply(404, {})
+        .replyWithError({statusCode: 404})
         // Error while fetching tags
         .get('/repos/foo/bar/tags?per_page=100&page=1')
         .reply(500);
@@ -453,7 +453,7 @@ describe('writePackage', () => {
       const ret = await writePackage('@soldair/foo', req, res);
       npmRequest.done();
       githubRequest.done();
-      expect(ret.error).to.match(/unknown error/);
+      expect(ret.error).to.match(/Error 500/);
       expect(ret.statusCode).to.equal(500);
     });
 
@@ -564,7 +564,7 @@ describe('writePackage', () => {
         .reply(200, {permissions: {push: true}})
         // Matching release for lerna-style tag. No need to check additional tags.
         .get('/repos/foo/bar/releases/tags/foo-v1.0.0')
-        .reply(404, {})
+        .replyWithError({statusCode: 404})
         .get('/repos/foo/bar/releases/tags/@soldair/foo@1.0.0')
         .reply(200, {name: '@soldair/foo@1.0.0'});
 
@@ -624,9 +624,9 @@ describe('writePackage', () => {
         .reply(200, {permissions: {push: true}})
         // No matching releases for either tag type.
         .get('/repos/foo/bar/releases/tags/foo-v1.0.0')
-        .reply(404, {})
+        .replyWithError({statusCode: 404})
         .get('/repos/foo/bar/releases/tags/@soldair/foo@1.0.0')
-        .reply(404, {})
+        .replyWithError({statusCode: 404})
         // But there is a matching tag for v1.0.0
         .get('/repos/foo/bar/tags?per_page=100&page=1')
         .reply(200, [{name: 'foo-v1.0.0'}]);
@@ -687,9 +687,9 @@ describe('writePackage', () => {
         .reply(200, {permissions: {push: true}})
         // No matching releases matching either style.
         .get('/repos/foo/bar/releases/tags/foo-v1.0.0')
-        .reply(404, {})
+        .replyWithError({statusCode: 404})
         .get('/repos/foo/bar/releases/tags/@soldair/foo@1.0.0')
-        .reply(404, {})
+        .replyWithError({statusCode: 404})
         // most recent release tag on GitHub is v1.0.0
         .get('/repos/foo/bar/tags?per_page=100&page=1')
         .reply(200, [{name: '@soldair/foo@1.0.0'}]);
@@ -750,9 +750,9 @@ describe('writePackage', () => {
         .reply(200, {permissions: {push: true}})
         // No matching releases for either tag style.
         .get('/repos/foo/bar/releases/tags/foo-v1.0.0')
-        .reply(404, {})
+        .replyWithError({statusCode: 404})
         .get('/repos/foo/bar/releases/tags/@soldair/foo@1.0.0')
-        .reply(404, {})
+        .replyWithError({statusCode: 404})
         // This is monorepo-style token but the tags on GH are not monorepo-style
         .get('/repos/foo/bar/tags?per_page=100&page=1')
         .reply(200, [{name: 'v1.0.0'}])


### PR DESCRIPTION

- [ ] Make sure to open an issue as a [bug/issue](https://github.com/GoogleCloudPlatform/wombat-dressing-room/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #158 

1. Adds a try/catch around the entire check to getReleaseForTags. If this fails for any reason then we will fall back to checking the tags.
2. Handles the 404 case for a release cleanly. The previous code was wrong because I assumed that the API used would return a `code` 404 and an empty response if the release was missing, similar to what happens if you call the GitHub API directly with `curl`. However, this client library we're using (which is not the standard one) actually returns an error object for this case. Unfortunately I could not find any definitions for the type of Error object they're using, but after trial and error we determined the error does have a property called `statusCode` that we can check. If it's 404 then we just continue to the next tag, if it's another error then we'll throw the error, but it will be caught by step 1 and we'll fall back to tags.
3. Updated all of the tests to use `replyWithError` to more closely match how the API behaves in reality.
4. Added a test for the case where we get a non-404 error from the getReleaseForTags call.
5. Fixed a problem with the error messages in `write-message`. If this method catches an error that isn't a `WombatServerError` then it would just say "unknown error." Now, it can handle either `WombatServerError` or just regular `Error` (which has a `message` property not a `statusMessage` property) but still returns an error with the same shape (before, it was just an object that had the same properties as WombatSeverError, now it will be an actual instance of it). I tested this change by causing a generic error by not providing all of the mocked API responses to `nock` in a test. Previously, the error message would be a cryptic "unknown error" and now the error actually contains the useful message from `nock`. This isn't directly related to the core issue I was facing but it made it easier to debug after I fixed this.

I tested this change by actually using this GitHub client library in a separate test program and observing it worked the way I wanted it to. See [this gist](https://gist.github.com/maribethb/3c128751b83d3f65c081a47682c23f56) which I invoked using `node index.js` which actually performs the GH API call (instead of relying on unit tests with mocked API responses). So I am reasonably confident this change works as intended now.
