### PR TITLE
fix: correct error message when the repository URL returns 404

### DIFF
--- a/packages/server/src/lib/github.ts
+++ b/packages/server/src/lib/github.ts
@@ -15,6 +15,7 @@
  */
 
 import {URL} from 'url';
+import {WombatServerError} from './wombat-server-error';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const gh = require('octonode');
@@ -26,7 +27,7 @@ let clientOptions: {} | undefined;
  * @param name repository name including username. ex: node/node or bcoe/yargs
  * @param token
  *
- * @returns GhUser
+ * @returns GhRepo
  */
 export const getRepo = (name: string, token: string): Promise<GhRepo> => {
   return new Promise((resolve, reject) => {
@@ -36,7 +37,10 @@ export const getRepo = (name: string, token: string): Promise<GhRepo> => {
       // bubbling this up as a unique error because its useful for folks to know
       // that the repo might not exist.
       if (status === 404) {
-        return reject(new Error('repository ' + name + ' doesnt exist'));
+        // Specifying nonexistent repository field is a bad request.
+        return reject(
+          new WombatServerError('repository ' + name + ' doesnt exist', 400)
+        );
       }
 
       if (err || status !== 200) {

--- a/packages/server/test/lib/write-package.ts
+++ b/packages/server/test/lib/write-package.ts
@@ -173,6 +173,52 @@ describe('writePackage', () => {
     githubRequest.done();
   });
 
+  it('returns correct error message when GitHub returns 404 for repository', async () => {
+    // There was a problem where a 404 error from GitHub API
+    // resulted in a 404 error from Wombat Dressing Room to npm CLI.
+
+    sinon.stub(writePackage.datastore, 'getPublishKey').resolves({
+      username: 'bcoe',
+      created: 1578630249529,
+      value: 'deadbeef',
+    });
+    sinon.stub(writePackage.datastore, 'getUser').resolves({
+      name: 'bcoe',
+      token: 'deadbeef',
+    });
+
+    // Mock existing package with repository info
+    const npmRequest = nock('https://registry.npmjs.org')
+      .get('/@soldair%2ffoo')
+      .reply(
+        200,
+        createPackument('@soldair/foo')
+          .addVersion('1.0.0', 'https://github.com/foo/bar')
+          .packument()
+      );
+
+    // Mock github returning 404 for the repository
+    const githubRequest = nock('https://api.github.com')
+      .get('/repos/foo/bar')
+      .reply(404);
+
+    const req = writePackageRequest(
+      {authorization: 'token: abc123'},
+      createPackument('@soldair/foo')
+        .addVersion('1.1.0', 'https://github.com/foo/bar')
+        .packument()
+    );
+    const res = mockResponse();
+
+    const ret = await writePackage('@soldair/foo', req, res);
+
+    // GitHub returning 404 means the request payload was invalid.
+    expect(ret.statusCode).to.equal(400);
+    expect(ret.error).to.match(/repository foo\/bar doesnt exist/);
+    npmRequest.done();
+    githubRequest.done();
+  });
+
   describe('releaseAs2FA', () => {
     it('appropriately routes initial package publication', async () => {
       // Fake that there's a releaseAs2FA key in datastore:


### PR DESCRIPTION
Wombat Dressing Room was returning "undefined" error message with 404 status code when the publication payload had an invalid repository URL.

```
npm error 404   ===============================
npm error 404   Publish service error
npm error 404   -------------------------------
npm error 404   undefined
npm error 404   ===============================
npm error 404   
npm error 404
npm error 404  '@google-automations/label-utils@6.1.0' is not in this registry.
```

The cause of this unclear error message is, I think, that the getRepo method returns `Error` (not WombatServerError`) that does not have status code or status message.

```typescript
export const getRepo = (name: string, token: string): Promise<GhRepo> => {
  return new Promise((resolve, reject) => {
    const client = gh.client(token, clientOptions);

    client.get('/repos/' + name, (err: Error, status: number, data: GhRepo) => {
      // bubbling this up as a unique error because its useful for folks to know
      // that the repo might not exist.
      if (status === 404) {
        return reject(new Error('repository ' + name + ' doesnt exist'));
      }
```

The error message is expecting the exception object to have statusMessage and statusCode.

```typescript
    try {
      await enforceRepositoryPermission(repoName, user);
    } catch (_e) {
      const e = _e as {statusMessage: string; statusCode: number};
      return respondWithError(res, e.statusMessage, e.statusCode);
```

Fixes https://github.com/GoogleCloudPlatform/wombat-dressing-room/issues/310
