### PR TITLE
build: use npm ci in CI workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,5 +12,5 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - run: node --version
-      - run: npm install
+      - run: npm ci
       - run: npm test


### PR DESCRIPTION
Switching from npm install to npm ci in CI workflows to ensure reproducible builds and mitigate supply chain risks by using the exact versions pinned in package-lock.json.