### PR TITLE
fix: npm deprecate validation failure for packages with missing repository in old versions

### DIFF
--- a/packages/server/src/lib/write-package.ts
+++ b/packages/server/src/lib/write-package.ts
@@ -164,9 +164,16 @@ export const writePackage = async (
   addRepo(latest);
 
   drainedBody = drainedBody || (await drainRequest(req));
+
   try {
-    for (const repoName of getReposFromIncomingBody(drainedBody)) {
-      reposToCheck.add(repoName);
+    if (!isMetadataUpdate(drainedBody, docFromNpm, newPackage)) {
+      for (const repoName of getReposFromIncomingBody(drainedBody)) {
+        reposToCheck.add(repoName);
+      }
+    } else {
+      console.info(
+        `Skipping incoming repos check for ${packageName} as it is a metadata-only update.`
+      );
     }
   } catch (e) {
     if (e instanceof WombatServerError) {
@@ -457,4 +464,39 @@ function getReposFromIncomingBody(body: Buffer): Set<string> {
   }
 
   return repos;
+}
+
+/**
+ * Detects if the incoming request is a metadata-only update (e.g., deprecation).
+ *
+ * It compares the versions in the incoming packument with the existing packument
+ * in the registry. If no new versions are being introduced, it is considered a
+ * metadata-only update.
+ *
+ * @param drainedBody - The request body as a Buffer.
+ * @param docFromNpm - The existing packument from the registry, if it exists.
+ * @param newPackage - Whether this is a publication of a new package.
+ * @returns True if it is a metadata-only update, false otherwise.
+ */
+function isMetadataUpdate(
+  drainedBody: Buffer,
+  docFromNpm: Packument | false | undefined,
+  newPackage: boolean
+): boolean {
+  try {
+    const incomingDoc = JSON.parse(drainedBody + '');
+    if (
+      !newPackage &&
+      docFromNpm &&
+      incomingDoc &&
+      typeof incomingDoc === 'object' &&
+      incomingDoc.versions
+    ) {
+      const newVers = newVersions(docFromNpm, incomingDoc);
+      return newVers.length === 0;
+    }
+  } catch (e) {
+    // If it's not valid JSON, we don't treat it as metadata update of a packument.
+  }
+  return false;
 }

--- a/packages/server/test/lib/write-package-repo-validation.ts
+++ b/packages/server/test/lib/write-package-repo-validation.ts
@@ -333,4 +333,69 @@ describe('writePackage repository validation', () => {
 
     nock.cleanAll();
   });
+
+  it('successfully deprecates (PUT with full packument) even if an old version lacks repository, as long as latest has it', async () => {
+    writePackage.datastore = Object.assign({}, datastore, {
+      getPublishKey: async (): Promise<PublishKey | false> => {
+        return {
+          username: 'suztomo',
+          created: 1578630249529,
+          value: 'deadbeef',
+        };
+      },
+      getUser: async (): Promise<false | User> => {
+        return {name: 'suztomo', token: 'deadbeef'};
+      },
+    });
+
+    writePackage.pipeToNpm = (
+      req: Request,
+      res: Response,
+      drainedBody: false | Buffer,
+      newPackage: boolean
+    ): Promise<WriteResponse> => {
+      return Promise.resolve({statusCode: 200, newPackage});
+    };
+
+    // Incoming request (simulating deprecation) has both versions
+    // 1.0.0 (no repo) and 1.1.0 (has repo)
+    const incomingPackument = createPackument('@soldair/foo')
+      .addVersion('1.0.0') // No repo
+      .addVersion('1.1.0', 'https://github.com/foo/bar') // Has repo
+      .packument();
+
+    // Simulate deprecation change
+    (incomingPackument.versions['1.0.0'] as any).deprecated = 'deprecated';
+
+    const req = writePackageRequest(
+      {authorization: 'token: abc123'},
+      incomingPackument
+    );
+    const res = mockResponse();
+
+    // Registry also has both versions
+    const npmRequest = nock('https://registry.npmjs.org')
+      .get('/@soldair%2ffoo')
+      .reply(
+        200,
+        createPackument('@soldair/foo')
+          .addVersion('1.0.0')
+          .addVersion('1.1.0', 'https://github.com/foo/bar')
+          .packument()
+      );
+
+    // Mock github permission check for the latest version's repo
+    const githubRequest = nock('https://api.github.com')
+      .get('/repos/foo/bar')
+      .reply(200, {permissions: {push: true}});
+
+    const ret = await writePackage('@soldair/foo', req, res);
+    npmRequest.done();
+    githubRequest.done();
+
+    expect(ret.statusCode).to.equal(200);
+    expect(ret.error).to.be.undefined;
+
+    nock.cleanAll();
+  });
 });


### PR DESCRIPTION
This PR fixes an issue where `npm deprecate` fails for packages that have historical versions missing the `repository` field in their metadata (e.g., `@ngtools/webpack`).

### Changes
* Detect metadata-only updates (like deprecation) by comparing incoming packument versions with the registry.
* If no new versions are being published, skip strict repository validation for all historical versions in the incoming body.
* We still verify that the user has push access to the repository of the `latest` version.

b/512428441