### PR TITLE
fix: Node 22 runtime

### DIFF
--- a/app-external.yaml
+++ b/app-external.yaml
@@ -1,2 +1,2 @@
-runtime: nodejs20
+runtime: nodejs22
 #service: external

--- a/app-internal.yaml
+++ b/app-internal.yaml
@@ -1,2 +1,2 @@
-runtime: nodejs20
+runtime: nodejs22
 #service: internal


### PR DESCRIPTION
We cannot deploy AppEngine Node 20 runtime any more. Let's upgrade
the runtime version.

